### PR TITLE
Maintain a lock count to fix isLocked

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@ First of all, WELCOME!! It is really great to receive contributions/suggestions,
 
 - Download and install [Node.JS](https://nodejs.org/en/download/).
 - [Fork this repository](https://help.github.com/articles/fork-a-repo/).
-- In a terminal, move to the directory where you've forked the repo and run the following command to install all the depedencies:
+- In a terminal, move to the directory where you've forked the repo and run the following command to install all the dependencies:
 ```
 npm install
 ```
 
 ## Making Changes
 
-- Create a topic branch from where you want to base your work. For example to branch from **master** and inmediately switch to the newly created branch, run the following command (replace *branch_name* with a proper name that describes the changes you want to submit):
+- Create a topic branch from where you want to base your work. For example to branch from **master** and immediately switch to the newly created branch, run the following command (replace *branch_name* with a proper name that describes the changes you want to submit):
 ```
 git checkout -b <branch-name>
 ```
@@ -25,7 +25,7 @@ npm run dev
 
 ## Submitting Changes
 
-- Be sure you have created one or more tests to reflect the intent of your change, and all the tests are passing (it won't let you proceed with the next items if these conditions are not met). 
+- Be sure you have created one or more tests to reflect the intent of your change, and all the tests are passing (it won't let you proceed with the next items if these conditions are not met).
 - Run the following command to push your changes to the topic branch you created in your fork of the repository:
 ```
 git push -u origin <branch-name>

--- a/src/mutex.js
+++ b/src/mutex.js
@@ -3,23 +3,23 @@ export default class Mutex {
     constructor() {
 
         this._locking = Promise.resolve();
-        this._locked = false;
+        this._locked = 0;
     }
 
     isLocked() {
 
-        return this._locked;
+        return 0 !== this._locked;
     }
 
     lock() {
 
-        this._locked = true;
+        ++this._locked;
 
         let unlockNext;
 
         let willLock = new Promise(resolve => unlockNext = resolve);
 
-        willLock.then(() => this._locked = false);
+        willLock.then(() => --this._locked);
 
         let willUnlock = this._locking.then(() => unlockNext);
 

--- a/test/mutex.js
+++ b/test/mutex.js
@@ -46,4 +46,17 @@ describe("Mutex", () => {
 
         await mutex.lock();
     });
+
+    it("should remain locked when one locker takes over from another", async () => {
+
+        let mutex = new Mutex();
+
+        let unlock = await mutex.lock();
+
+        setTimeout(unlock, 0);
+
+        await mutex.lock();
+
+        assert(mutex.isLocked());
+    });
 });


### PR DESCRIPTION
Maintain a count of pending lockers in `this._locked` instead of a boolean.
This ensures the correct `isLocked` behavior when there are multiple lockers.

Fixes #1.